### PR TITLE
Update bungeecord-api dependancy (#10)

### DIFF
--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.16-R0.4-SNAPSHOT</version>
+            <version>1.16-R0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* Update bungeecord-api dependancy

bungeecord-api has been updated from `1.16-R0.4-SNAPSHOT` to `1.16-R0.5-SNAPSHOT`.

* use 1.16-R0.4